### PR TITLE
Hide main window and adjust taskbar

### DIFF
--- a/SystemMonitor/SystemMonitorApp.swift
+++ b/SystemMonitor/SystemMonitorApp.swift
@@ -18,6 +18,8 @@ struct SystemMonitorApp: App {
             ContentView(systemInfo: systemInfo)
                 .onAppear {
                     setupWindowBehavior()
+                    // 默认隐藏主窗口
+                    hideMainWindowOnLaunch()
                 }
         }
         .windowStyle(.hiddenTitleBar)
@@ -84,6 +86,13 @@ struct SystemMonitorApp: App {
             }
         }
         isMainWindowVisible = true
+    }
+    
+    private func hideMainWindowOnLaunch() {
+        // 延迟隐藏主窗口，确保窗口已经创建
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            self.minimizeToStatusBar()
+        }
     }
 }
 


### PR DESCRIPTION
Hide main window by default, enable double-click on status bar to show it, and improve popover visibility as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-fecf1d73-b392-48cd-b8d6-830aabc94a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fecf1d73-b392-48cd-b8d6-830aabc94a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

